### PR TITLE
Fix Crash on iOS 13

### DIFF
--- a/ios/RNSearchBarManager.m
+++ b/ios/RNSearchBarManager.m
@@ -75,7 +75,11 @@ RCT_CUSTOM_VIEW_PROPERTY(hideBackground, BOOL, RNSearchBar)
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(cancelButtonText, NSString, RNSearchBar) {
-    [view setValue:[RCTConvert NSString:json] forKey:@"_cancelButtonText"];
+    if (@available(iOS 9.0, *)) {
+        [[UIBarButtonItem appearanceWhenContainedInInstancesOfClasses:@[[UISearchBar class]]] setTitle:[RCTConvert NSString:json]];
+    } else {
+        [[UIBarButtonItem appearanceWhenContainedIn: [UISearchBar class], nil] setTitle:[RCTConvert NSString:json]];
+    }
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(editable, BOOL, RNSearchBar)


### PR DESCRIPTION
Setting the _cancelButtonText property on the UISearchBar causes a crash on iOS 13+, most likely because apple has gotten rid or renamed the private property hence the crash. Nonetheless, I found a solution that fixes this issue.

A screenshot is attached of the crash
![Screenshot 2019-08-01 at 17 48 58](https://user-images.githubusercontent.com/6454286/62312208-86feb400-b485-11e9-9859-d0429be9b399.png)
